### PR TITLE
Rewrite qTip2

### DIFF
--- a/topic_preview/contrib/extras/qTip2/qTip2_install.xml
+++ b/topic_preview/contrib/extras/qTip2/qTip2_install.xml
@@ -163,7 +163,6 @@ $(document).ready(function(){
 	});
 });
 </script>
-]]></action>
 <!-- ENDIF -->]]></action>
 			</edit>
 		</open>


### PR DESCRIPTION
The current version is optimized - it includes qTip2 script only once. The previous version put qTip2 on each link.
